### PR TITLE
Issue #28: Update to Backdrop version 1.11.1.

### DIFF
--- a/1/apache/Dockerfile
+++ b/1/apache/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev \
 WORKDIR /var/www/html
 
 # https://github.com/backdrop/backdrop/releases
-ENV BACKDROP_VERSION 1.10.1
-ENV BACKDROP_MD5 1c6582dfbf8ecd422e4338e3a5157504
+ENV BACKDROP_VERSION 1.11.1
+ENV BACKDROP_MD5 2785b5bf7ede351939abb9187b886c40
 
 RUN curl -fSL "https://github.com/backdrop/backdrop/archive/${BACKDROP_VERSION}.tar.gz" -o backdrop.tar.gz \
   && echo "${BACKDROP_MD5} *backdrop.tar.gz" | md5sum -c - \

--- a/1/fpm/Dockerfile
+++ b/1/fpm/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev \
 WORKDIR /var/www/html
 
 # https://github.com/backdrop/backdrop/releases
-ENV BACKDROP_VERSION 1.10.1
-ENV BACKDROP_MD5 1c6582dfbf8ecd422e4338e3a5157504
+ENV BACKDROP_VERSION 1.11.1
+ENV BACKDROP_MD5 2785b5bf7ede351939abb9187b886c40
 
 RUN curl -fSL "https://github.com/backdrop/backdrop/archive/${BACKDROP_VERSION}.tar.gz" -o backdrop.tar.gz \
 	&& echo "${BACKDROP_MD5} *backdrop.tar.gz" | md5sum -c - \


### PR DESCRIPTION
Fixes #https://github.com/backdrop-ops/backdrop-docker/issues/28 