### PR TITLE
Issue #32: Update to the latest release of Backdrop CMS - 1.12.2.

### DIFF
--- a/1/apache/Dockerfile
+++ b/1/apache/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev \
 WORKDIR /var/www/html
 
 # https://github.com/backdrop/backdrop/releases
-ENV BACKDROP_VERSION 1.11.3
-ENV BACKDROP_MD5 548333a6eec104af1ff6f19cd73791e4
+ENV BACKDROP_VERSION 1.12.2
+ENV BACKDROP_MD5 c19b009b17d33f44f31350516b67fc33
 
 RUN curl -fSL "https://github.com/backdrop/backdrop/archive/${BACKDROP_VERSION}.tar.gz" -o backdrop.tar.gz \
   && echo "${BACKDROP_MD5} *backdrop.tar.gz" | md5sum -c - \

--- a/1/fpm/Dockerfile
+++ b/1/fpm/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y libpng-dev libjpeg-dev libpq-dev \
 WORKDIR /var/www/html
 
 # https://github.com/backdrop/backdrop/releases
-ENV BACKDROP_VERSION 1.11.3
-ENV BACKDROP_MD5 548333a6eec104af1ff6f19cd73791e4
+ENV BACKDROP_VERSION 1.12.2
+ENV BACKDROP_MD5 c19b009b17d33f44f31350516b67fc33
 
 RUN curl -fSL "https://github.com/backdrop/backdrop/archive/${BACKDROP_VERSION}.tar.gz" -o backdrop.tar.gz \
 	&& echo "${BACKDROP_MD5} *backdrop.tar.gz" | md5sum -c - \


### PR DESCRIPTION
Fixes https://github.com/backdrop-ops/backdrop-docker/issues/32