### PR TITLE
Chore: reduce attack surface for Docker image

### DIFF
--- a/1/apache/Dockerfile
+++ b/1/apache/Dockerfile
@@ -4,7 +4,7 @@ FROM php:8.1-apache
 RUN a2enmod rewrite
 
 # install the PHP extensions we need
-RUN apt-get update && apt-get install -y libzip-dev libonig-dev libpng-dev libjpeg-dev libpq-dev \
+RUN apt-get update && apt-get install -y --no-install-recommends libzip-dev libonig-dev libpng-dev libjpeg-dev libpq-dev \
 	&& rm -rf /var/lib/apt/lists/* \
 	&& docker-php-ext-configure gd --with-jpeg=/usr \
 	&& docker-php-ext-install gd mbstring pdo pdo_mysql pdo_pgsql zip


### PR DESCRIPTION
Hi,

This pull request includes a small improvement for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

In detail:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

As quoted from [CIS Docker Benchmark v1.5.0](https://www.cisecurity.org/benchmark/docker):
>**4.3 Ensure that unnecessary packages are not installed in the container**
>**Description:**
>Containers should have as small a footprint as possible, and should not contain unnecessary software packages which could increase their attack surface.
>**Rationale:**
>Unnecessary software should not be installed into containers, as doing so increases their attack surface. Only packages strictly necessary for the correct operation of the application being deployed should be installed.

The differences between two builds are summarized in the below table:
||Before improvement|After improvement|
|-----------------------|-------|-------|
|Newly intalled packages| 16    |  15  |
|Image size             | 450MB | 450MB |
|Build time             | 104s  | 88s  |

- Removed unnecessary packages after the improvement: `libpng-tools`.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.