### PR TITLE
Removing expose commands from docker file

### DIFF
--- a/1/apache/Dockerfile
+++ b/1/apache/Dockerfile
@@ -24,7 +24,5 @@ RUN curl -fSL "https://github.com/backdrop/backdrop/archive/refs/tags/${BACKDROP
 # Add custom entrypoint to set BACKDROP_SETTINGS correctly
 COPY docker-entrypoint.sh /entrypoint.sh
 
-EXPOSE 80
-
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["apache2-foreground"]

--- a/1/fpm/Dockerfile
+++ b/1/fpm/Dockerfile
@@ -22,7 +22,5 @@ RUN curl -fSL "https://github.com/backdrop/backdrop/archive/${BACKDROP_VERSION}.
 # Add custom entrypoint to set BACKDROP_SETTINGS correctly
 COPY docker-entrypoint.sh /entrypoint.sh
 
-EXPOSE 80
-
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["php-fpm"]


### PR DESCRIPTION
These were added as part of the configuration fixes, but are not needed.  