### PR TITLE
Update to Backdrop 1.30.0 - 10th anniversary release

### DIFF
--- a/1/apache/Dockerfile
+++ b/1/apache/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends libzip-dev libo
 WORKDIR /var/www/html
 
 # https://github.com/backdrop/backdrop/releases
-ENV BACKDROP_VERSION=1.29.3
-ENV BACKDROP_MD5=edaca7afb7adf3785a97002ea5183407
+ENV BACKDROP_VERSION=1.30.0
+ENV BACKDROP_MD5=b4510de5df47fc277610f1eebceb7ac4
 
 RUN curl -fSL "https://github.com/backdrop/backdrop/archive/refs/tags/${BACKDROP_VERSION}.tar.gz" -o backdrop.tar.gz \
   && echo "${BACKDROP_MD5} *backdrop.tar.gz" | md5sum -c - \

--- a/1/fpm/Dockerfile
+++ b/1/fpm/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y libzip-dev libonig-dev libpng-dev libjp
 WORKDIR /var/www/html
 
 # https://github.com/backdrop/backdrop/releases
-ENV BACKDROP_VERSION=1.29.3
-ENV BACKDROP_MD5=edaca7afb7adf3785a97002ea5183407
+ENV BACKDROP_VERSION=1.30.0
+ENV BACKDROP_MD5=b4510de5df47fc277610f1eebceb7ac4
 
 RUN curl -fSL "https://github.com/backdrop/backdrop/archive/${BACKDROP_VERSION}.tar.gz" -o backdrop.tar.gz \
 	&& echo "${BACKDROP_MD5} *backdrop.tar.gz" | md5sum -c - \

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 # Supported tags and Dockerfile links
 
 
-- [`1.29.3-apache`, `1.29.3`, `1-apache`, `1` (*1/apache/Dockerfile*)](https://github.com/kalabox/backdrop-docker/blob/master/1/apache/Dockerfile)
-- [`1.29.3-fpm`, `1-fpm` (*1/fpm/Dockerfile*)](https://github.com/kalabox/backdrop-docker/blob/master/1/fpm/Dockerfile)
+- [`1.30.0-apache`, `1.30.0`, `1-apache`, `1` (*1/apache/Dockerfile*)](https://github.com/kalabox/backdrop-docker/blob/master/1/apache/Dockerfile)
+- [`1.30.0-fpm`, `1-fpm` (*1/fpm/Dockerfile*)](https://github.com/kalabox/backdrop-docker/blob/master/1/fpm/Dockerfile)
 
 
 # Launch Backdrop using Docker


### PR DESCRIPTION
This resolves #80, updating the docker image to the latest release 1.30.0.  