### PR TITLE
Updating to the Latest Release of Backdrop 1.32.0

### DIFF
--- a/1/apache/Dockerfile
+++ b/1/apache/Dockerfile
@@ -12,8 +12,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends libzip-dev libo
 WORKDIR /var/www/html
 
 # https://github.com/backdrop/backdrop/releases
-ENV BACKDROP_VERSION=1.31.0
-ENV BACKDROP_MD5=0204d479a71ac692039a9f7b1e50409f
+ENV BACKDROP_VERSION=1.32.0
+ENV BACKDROP_MD5=dd1b43ba169fb750c64cc2da035b4ceb
 
 RUN curl -fSL "https://github.com/backdrop/backdrop/archive/refs/tags/${BACKDROP_VERSION}.tar.gz" -o backdrop.tar.gz \
   && echo "${BACKDROP_MD5} *backdrop.tar.gz" | md5sum -c - \

--- a/1/fpm/Dockerfile
+++ b/1/fpm/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y libzip-dev libonig-dev libpng-dev libjp
 WORKDIR /var/www/html
 
 # https://github.com/backdrop/backdrop/releases
-ENV BACKDROP_VERSION=1.31.0
-ENV BACKDROP_MD5=0204d479a71ac692039a9f7b1e50409f
+ENV BACKDROP_VERSION=1.32.0
+ENV BACKDROP_MD5=dd1b43ba169fb750c64cc2da035b4ceb
 
 RUN curl -fSL "https://github.com/backdrop/backdrop/archive/${BACKDROP_VERSION}.tar.gz" -o backdrop.tar.gz \
 	&& echo "${BACKDROP_MD5} *backdrop.tar.gz" | md5sum -c - \

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 # Supported tags and Dockerfile links
 
 
-- [`1.31.0-apache`, `1.31.0`, `1-apache`, `1` (*1/apache/Dockerfile*)](https://github.com/kalabox/backdrop-docker/blob/master/1/apache/Dockerfile)
-- [`1.31.0-fpm`, `1-fpm` (*1/fpm/Dockerfile*)](https://github.com/kalabox/backdrop-docker/blob/master/1/fpm/Dockerfile)
+- [`1.32.0-apache`, `1.32.0`, `1-apache`, `1` (*1/apache/Dockerfile*)](https://github.com/kalabox/backdrop-docker/blob/master/1/apache/Dockerfile)
+- [`1.32.0-fpm`, `1-fpm` (*1/fpm/Dockerfile*)](https://github.com/kalabox/backdrop-docker/blob/master/1/fpm/Dockerfile)
 
 
 # Launch Backdrop using Docker


### PR DESCRIPTION
This updates the docker image version of Backdrop CMS to the latest release 1.32.0